### PR TITLE
Improve testing of devices

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 CC?=gcc
 INSTALL?=install
 DESTDIR=/usr/bin
-CFLAGS=-Wall -Werror
+CFLAGS=-Wall -Werror -O3 -flto
 
 all: scam-o-matic
 
-scam-o-matic: scam-o-matic.c
+scam-o-matic: scam-o-matic.c Makefile
 	$(CC) $(CFLAGS) -o scam-o-matic scam-o-matic.c
 
 clean:

--- a/scam-o-matic.c
+++ b/scam-o-matic.c
@@ -8,6 +8,7 @@
 #include <fcntl.h>
 #include <inttypes.h>
 #include <errno.h>
+#include <time.h>
 
 //#define MACOSX
 
@@ -28,14 +29,28 @@
 
 /* shamelessly ripped from linux kernel */
 
+static int start_s1, start_s2, start_s3, seed_init;
 static int s1, s2, s3;
-
 
 void prandom_reset()
 {
-    s1 = 100;
-    s2 = 200;
-    s3 = 300;
+    if (!seed_init) {
+        start_s1 = time(NULL);
+        start_s2 = 200;
+        start_s3 = 300;
+        seed_init = 1;
+
+        int fd = open("/dev/urandom", O_RDONLY);
+        if (fd >= 0) {
+            read(fd, &start_s2, sizeof(start_s2));
+            read(fd, &start_s3, sizeof(start_s3));
+            close(fd);
+        }
+    }
+
+    s1 = start_s1;
+    s2 = start_s2;
+    s3 = start_s3;
 }
 
 uint32_t prandom32()


### PR DESCRIPTION
Use a random seed which is time based and used /dev/urandom if available to avoid any chance of the fixed seed hardcoded somehow into a fake device. A random seed means the output stream will be unique for each run.

Second change is to have two different passes, one that writes the entire device and another that verifies it. This way a device that fakes the data by keeping only a little bit of the last data written will not be able to fool it and storing the data will require full advertised storage capacity.

A small side effect should be some speedup by not requiring a flush after every write, only one flush is needed on the border between writing and verifying and even that is not really needed except for extremely small devices that can be read completely before the data will get written on its own.
